### PR TITLE
Use active player list for ruler selection

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -562,21 +562,25 @@ SUBSYSTEM_DEF(ticker)
 		CHECK_TICK
 
 /datum/controller/subsystem/ticker/proc/select_ruler()
-	switch(rulertype)
-		if("King")
-			for(var/mob/living/carbon/human/K in world)
-				if(istype(K, /mob/living/carbon/human/dummy))
-					continue
-				if(K.job == "King")
-					rulermob = K
-					return
-		if("Queen")
-			for(var/mob/living/carbon/human/Q in world)
-				if(istype(Q, /mob/living/carbon/human/dummy))
-					continue
-				if(Q.job == "Queen")
-					rulermob = Q
-					return
+       var/list/players = list()
+       for(var/mob/living/carbon/human/H in GLOB.player_list)
+               if(istype(H, /mob/living/carbon/human/dummy))
+                       continue
+               if(!H.client)
+                       continue
+               players += H
+
+       switch(rulertype)
+               if("King")
+                       for(var/mob/living/carbon/human/K in players)
+                               if(K.job == "King")
+                                       rulermob = K
+                                       return
+               if("Queen")
+                       for(var/mob/living/carbon/human/Q in players)
+                               if(Q.job == "Queen")
+                                       rulermob = Q
+                                       return
 
 /datum/controller/subsystem/ticker/proc/collect_minds()
 	for(var/i in GLOB.new_player_list)


### PR DESCRIPTION
## Summary
- Optimize ruler selection by iterating over active player list instead of scanning the whole world
- Filter out dummies and non-player mobs before searching for King or Queen

## Testing
- `bash tools/travis/check_filedirs.sh roguetown.dme`
- `bash tools/travis/check_grep.sh` *(fails: Non-TGM map format, base /turf path use, unmanaged globals, trailing newline and map reference issues)*

Please recompile `roguetown.dme` with Dream Maker to incorporate these changes.

------
https://chatgpt.com/codex/tasks/task_e_68bf0c41f740832ba3cbd27486768d7a